### PR TITLE
chore: Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,20 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@crunchloop/mcp-devcontainers",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@crunchloop/mcp-devcontainers",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@devcontainers/cli": "^0.75.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crunchloop/mcp-devcontainers",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "MCP for devcontainers",
   "private": false,
   "license": "MIT",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import * as devcontainers from "./devcontainer.js";
 
 const server = new McpServer({
   name: "devcontainers",
-  version: "0.0.2"
+  version: "0.0.3"
 });
 
 server.tool(


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for publishing the package to npm and updates the package version to `0.0.3`. These changes ensure the package is automatically published when a release is created and that the versioning is consistent across the project.

### Workflow automation:
* Added a new GitHub Actions workflow in `.github/workflows/release.yaml` to publish the package to npm. The workflow triggers on release events, sets up a Node.js environment, installs dependencies, and publishes the package with provenance and public access.

### Version updates:
* Updated the `version` field in `package.json` from `0.0.2` to `0.0.3` to reflect the new release.
* Updated the `version` property in the `McpServer` initialization in `src/server.ts` to match the new package version (`0.0.3`).