### PR TITLE
chore: Add repo to package.json

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "private": false,
   "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crunchloop/mcp-devcontainers.git"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and the `package.json` file to improve the release process and repository metadata. The most important changes involve renaming a workflow job for clarity and adding repository information to the `package.json` file.

### Workflow updates:
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL6-R6): Renamed the `build` job to `publish` to better reflect its purpose in the release workflow.

### Metadata updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R8-R11): Added a `repository` field with the repository type and URL to provide metadata about the project's source.