### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The MCP Devcontainers is a Model Context Protocol (MCP) server that provides a simple integration with the [devcontainers cli](https://github.com/devcontainers/cli).
 
+<a href="https://glama.ai/mcp/servers/@crunchloop/mcp-devcontainers">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@crunchloop/mcp-devcontainers/badge" alt="Devcontainers MCP server" />
+</a>
+
 ## Dependencies
 
 This server requires **Docker** to be installed and running on your system, as it is used by the [devcontainers cli](https://github.com/devcontainers/cli) to build and manage development containers.


### PR DESCRIPTION
This PR adds a badge for the [MCP Devcontainers](https://glama.ai/mcp/servers/@crunchloop/mcp-devcontainers) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@crunchloop/mcp-devcontainers">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@crunchloop/mcp-devcontainers/badge" alt="Devcontainers MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.